### PR TITLE
Prevent NativeVote menu callback from freeing in-use forward handle

### DIFF
--- a/addons/sourcemod/scripting/nativevotes.sp
+++ b/addons/sourcemod/scripting/nativevotes.sp
@@ -821,7 +821,7 @@ Action DoAction(NativeVote vote, MenuAction action, int param1, int param2, Acti
 {
 	Action res = def_res;
 
-	Handle handler = Data_GetHandler(vote);
+	Handle handler = CloneHandle(Data_GetHandler(vote));
 #if defined LOG
 	LogMessage("Calling Menu forward for vote: %d, handler: %d, action: %d, param1: %d, param2: %d", vote, handler, action, param1, param2);
 #endif
@@ -831,6 +831,7 @@ Action DoAction(NativeVote vote, MenuAction action, int param1, int param2, Acti
 	Call_PushCell(param1);
 	Call_PushCell(param2);
 	Call_Finish(res);
+	delete handler;
 	return res;
 }
 


### PR DESCRIPTION
Quick-fix while alliedmodders/sourcemod#1041 gets sorted out.

SourceMod doesn't seem to take kindly to a forward handle being deleted while it's being invoked, which is what `Handler_NV_MapVoteMenu` does with `NativeVote.Clear()` in `nativevotes_mapchooser.sp`.  This seemingly didn't have disastrous consequences until Debian 10.

All this does is ensure that the handle remains valid for the duration of the private forward call.